### PR TITLE
Remove data event listener and add startWaitTime option

### DIFF
--- a/tasks/express.js
+++ b/tasks/express.js
@@ -16,11 +16,12 @@ module.exports = function(grunt) {
 
   grunt.registerMultiTask('express', 'Start an express web server', function() {
     var options = this.options({
-      args:       [ ],
-      background: true,
-      error:      function(err, result, code) { /* Callback has to exist */ },
-      fallback:   function() { /* Prevent EADDRINUSE from breaking Grunt */ },
-      port:       3000
+      args:          [ ],
+      background:    true,
+      error:         function(err, result, code) { /* Callback has to exist */ },
+      fallback:      function() { /* Prevent EADDRINUSE from breaking Grunt */ },
+      port:          3000,
+      startWaitTime: 500
     });
 
     options.script = path.resolve(options.script);

--- a/tasks/lib/server.js
+++ b/tasks/lib/server.js
@@ -47,10 +47,13 @@ module.exports = function(grunt) {
           fallback: options.fallback
         }, options.error);
 
-        server.stdout.on('data', finished);
-
         server.stdout.pipe(process.stdout);
         server.stderr.pipe(process.stderr);
+        if(options.startWaitTime) {
+          setTimeout(function(){
+            finished();
+          }, options.startWaitTime);
+        }
       } else {
         // Server is ran in current process
         server = require(options.script);

--- a/test/server.js
+++ b/test/server.js
@@ -2,6 +2,7 @@
  * Test Server
  */
 
+console.log("Express");
 var app = require('./app');
 
 module.exports = app.listen(app.get('port'), function() {


### PR DESCRIPTION
Hi @ericclemmons

In this code, your grunt task waits for writing console log, `server.stdout.on('data', finished);`.
However, if `console.log("test");` put on top of the express code `server.js`, this code doesn't work well.

like this:

``` js
console.log("Express"); // emit data event...
var app = require('./app');

module.exports = app.listen(app.get('port'), function() {
  console.log("Express server listening on port " + app.get('port'));
});
```

So I add an option startWaitTime.

If you accept, please merge it.
