### PR TITLE
Add CoffeeScript support & add synchronous foreground process support...

### DIFF
--- a/tasks/lib/server.js
+++ b/tasks/lib/server.js
@@ -42,7 +42,7 @@ module.exports = function(grunt) {
       done = grunt.task.current.async();
 
       // Set PORT for new processes
-      serverEnv = grunt._.assign({}, process.env, {PORT: options.port});
+      var serverEnv = grunt.util._.extend({}, process.env, {PORT: options.port});
 
       // Spawn the express server
       server = grunt.util.spawn({


### PR DESCRIPTION
Hi, this is a very small patch, just lets you specify the command to use as 'coffee' instead of 'node' when running the (express) server script...
Please let me know if it looks ok?
