### PR TITLE
Add NODE_ENV option

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -15,8 +15,8 @@ module.exports = function(grunt) {
     jshint: {
       all: [
         'Gruntfile.js',
-        'tasks/*.js',
-        'tests/*.js',
+        'tasks/**/*.js',
+        'test/*.js',
       ],
       options: {
         jshintrc: '.jshintrc',
@@ -38,6 +38,9 @@ module.exports = function(grunt) {
       },
       custom_port: {
         src: 'test/custom_port_test.js'
+      },
+      custom_node_env: {
+        src: 'test/custom_node_env_test.js'
       },
       custom_delay: {
         src: 'test/custom_delay_test.js'
@@ -65,6 +68,12 @@ module.exports = function(grunt) {
       custom_port: {
         options: {
           port: 8080,
+          output: "Express server listening on port .+"
+        }
+      },
+      custom_node_env: {
+        options: {
+          node_env: "production",
           output: "Express server listening on port .+"
         }
       },
@@ -104,6 +113,7 @@ module.exports = function(grunt) {
     'express:defaults', 'nodeunit:defaults',
     'express:custom_args', 'nodeunit:custom_args',
     'express:custom_port', 'nodeunit:custom_port',
+    'express:custom_node_env', 'nodeunit:custom_node_env',
     'express:custom_delay', 'nodeunit:custom_delay',
     'express:custom_output', 'nodeunit:custom_output',
     'express:stoppable', 'express:stoppable:stop', 'nodeunit:stoppable'

--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ grunt.initConfig({
     },
     prod: {
       options: {
-        script: 'path/to/prod/server.js'
+        script: 'path/to/prod/server.js',
+        node_env: 'production'
       }
     }
     test: {
@@ -72,6 +73,9 @@ or within each individual server task.
       // Override node env's PORT
       port: 3000,
 
+      // Override node env's NODE_ENV
+      node_env: undefined,
+
       // Consider the server to be "running" after an explicit delay (in milliseconds)
       // (e.g. when server has no initial output)
       delay: 0,
@@ -97,7 +101,7 @@ when the server has officially started.
 
 #### Starting the server
 
-If you have a server defined named `dev`, you can start the server by running `expess:dev`.
+If you have a server defined named `dev`, you can start the server by running `express:dev`.
 
 #### Stopping the server
 

--- a/tasks/express.js
+++ b/tasks/express.js
@@ -17,6 +17,7 @@ module.exports = function(grunt) {
   grunt.registerMultiTask('express', 'Start an express web server', function() {
     var options = this.options({
       args:          [ ],
+      node_env:      undefined,
       background:    true,
       error:         function(err, result, code) { /* Callback has to exist */ },
       fallback:      function() { /* Prevent EADDRINUSE from breaking Grunt */ },

--- a/tasks/lib/server.js
+++ b/tasks/lib/server.js
@@ -30,7 +30,7 @@ module.exports = function(grunt) {
 
           return;
         }
-      };
+      }
 
       grunt.log.writeln('Starting '.cyan + (options.background ? 'background' : 'foreground') + ' Express server');
 
@@ -38,6 +38,11 @@ module.exports = function(grunt) {
 
       // Set PORT for new processes
       process.env.PORT = options.port;
+
+      // Set NODE_ENV for new processes
+      if (options.node_env) {
+        process.env.NODE_ENV = options.node_env;
+      }
 
       if (options.background) {
         server = grunt.util.spawn({
@@ -55,7 +60,9 @@ module.exports = function(grunt) {
           server.stdout.on('data', function(data){
             var message = "" + data;
             var regex = new RegExp(options.output, "gi");
-            if (message.match(regex)) finished();
+            if (message.match(regex)) {
+              finished();
+            }
           });
         }
 
@@ -79,7 +86,7 @@ module.exports = function(grunt) {
         server.kill('SIGTERM');
         process.removeAllListeners();
         server = null;
-      };
+      }
 
       finished();
     }

--- a/test/app.js
+++ b/test/app.js
@@ -1,9 +1,19 @@
+"use strict";
+
 var express = require('express');
 var app     = module.exports = express();
 var args = process.argv;
 
-app.set('port', process.env.PORT || 3000);
-app.use(express.static(__dirname + '/../test/fixtures'));
+app.configure(function() {
+  app.set('port', process.env.PORT || 3000);
+  app.use(express.static(__dirname + '/../test/fixtures'));
+});
+
+app.configure('production', function() {
+  app.get('/production', function(req, res) {
+    res.send("Production Howdy!");
+  });
+});
 
 // Setup simple echo for each additional argument passed for testing
 args.slice(2).forEach(function(arg) {

--- a/test/custom_node_env_test.js
+++ b/test/custom_node_env_test.js
@@ -1,0 +1,25 @@
+/*
+ * grunt-express-server
+ * https://github.com/ericclemmons/grunt-express-server
+ *
+ * Copyright (c) 2013 Eric Clemmons
+ * Licensed under the MIT license.
+ */
+
+'use strict';
+
+var get = require('./lib/get');
+
+module.exports.custom_node_env = {
+  test_site_configured_for_production: function(test) {
+    test.expect(2);
+
+    get('http://localhost:3000/production', function(res, body) {
+      test.equal(res.statusCode, 200, 'should return 200');
+      test.equal(body, 'Production Howdy!', 'should return static page');
+      test.done();
+    }, function(err) {
+      test.done();
+    });
+  }
+};

--- a/test/defaults_test.js
+++ b/test/defaults_test.js
@@ -17,7 +17,6 @@ module.exports.defaults = {
     try {
       get('http://localhost:3000/hello.txt', function(res, body) {
         throw new Error('Server should not be running yet');
-        test.done();
       }, function(err) {
         test.equals('ECONNREFUSED', err.code);
         test.done();

--- a/test/server.js
+++ b/test/server.js
@@ -1,3 +1,5 @@
+"use strict";
+
 /**
  * Test Server
  */


### PR DESCRIPTION
I tried to base this on the port option as much as possible.  Here's a
summary of what I've done.
- Added the NODE_ENV option with a default of undefined
- Updated README with option
- Added unit test in `custom_node_env_test.js` (modified the app.js to
  have a configure('production') piece)
- Fixed some jshint pathing that was missing files and fixed jshint
  errors it found.

Feedback welcome if you'd like something altered.
