### PR TITLE
Fix Issue #11 (server restarts don't work on Windows)

### DIFF
--- a/tasks/lib/server.js
+++ b/tasks/lib/server.js
@@ -13,6 +13,15 @@ module.exports = function(grunt) {
   var server  = null; // Store server between live reloads to close/restart express
   var backup  = JSON.parse(JSON.stringify(process.env)); // Clone process.env
 
+  // For some weird reason, on Windows the process.env stringify produces a "Path" 
+  // member instead of a "PATH" member, and grunt chokes when it can't find PATH.
+  if (!backup.PATH) {
+    if (backup.Path) {
+      backup.PATH = backup.Path;
+      delete backup.Path;
+    }
+  }
+
   var finished = function() {
     if (done) {
       done();


### PR DESCRIPTION
Fix Issue #11 (server restarts don't work on Windows) by fixing up the backup environment that is saved off so that the path member is always in uppercase.
