### PR TITLE
Adding option for custom node command to enable CoffeeScript support

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -33,6 +33,9 @@ module.exports = function(grunt) {
       defaults: {
         src: 'test/defaults_test.js'
       },
+      custom_cmd: {
+        src: 'test/custom_cmd_test.js'
+      },
       custom_args: {
         src: 'test/custom_args_test.js'
       },
@@ -59,6 +62,13 @@ module.exports = function(grunt) {
         port: 3000
       },
       defaults: {},
+      custom_cmd: {
+        options: {
+          script: './test/coffeescript-server.coffee',
+          cmd: "coffee",
+          output: "Express server listening on port .+"
+        }
+      },
       custom_args: {
         options: {
           args: [ 1, 2],
@@ -116,6 +126,7 @@ module.exports = function(grunt) {
   grunt.registerTask('test', [
     'clean',
     'express:defaults', 'nodeunit:defaults',
+    'express:custom_cmd', 'nodeunit:custom_cmd',
     'express:custom_args', 'nodeunit:custom_args',
     'express:custom_port', 'nodeunit:custom_port',
     'express:custom_node_env', 'nodeunit:custom_node_env',

--- a/README.md
+++ b/README.md
@@ -58,6 +58,10 @@ or within each individual server task.
 ```js
   express: {
     options: {
+      // Override the command used to start the server.
+      // (e.g. 'coffee' instead of the default 'node' to enable CoffeeScript support)
+      cmd: undefined,
+
       // Will turn into: `node path/to/server.js ARG1 ARG2 ... ARGN`
       args: [ ],
 

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "grunt-cli": "~0.1.6",
     "grunt-contrib-jshint": "~0.1.1",
     "grunt-contrib-clean": "~0.4.0",
-    "grunt-contrib-nodeunit": "~0.1.2"
+    "grunt-contrib-nodeunit": "~0.1.2",
+    "coffee-script": "1.6.3"
   },
   "peerDependencies": {
     "grunt": "~0.4.0"

--- a/tasks/express.js
+++ b/tasks/express.js
@@ -16,6 +16,7 @@ module.exports = function(grunt) {
 
   grunt.registerMultiTask('express', 'Start an express web server', function() {
     var options = this.options({
+      cmd:           undefined,
       args:          [ ],
       node_env:      undefined,
       background:    true,

--- a/tasks/lib/server.js
+++ b/tasks/lib/server.js
@@ -61,7 +61,7 @@ module.exports = function(grunt) {
 
       if (options.background) {
         server = grunt.util.spawn({
-          cmd:      process.argv[0],
+          cmd:      options.cmd || process.argv[0],
           args:     options.args,
           env:      process.env,
           fallback: options.fallback

--- a/test/coffeescript-app.coffee
+++ b/test/coffeescript-app.coffee
@@ -1,0 +1,8 @@
+"use strict"
+express = require("express")
+app = module.exports = express()
+app.configure ->
+  app.set "port", process.env.PORT or 3000
+
+app.get "/", (req, res) ->
+  res.send "Howdy from CoffeeScript!"

--- a/test/coffeescript-server.coffee
+++ b/test/coffeescript-server.coffee
@@ -1,0 +1,20 @@
+"use strict"
+
+###
+Test Server - CoffeeScript Edition
+###
+app = require("./coffeescript-app")
+start = Date.now()
+log = (message) ->
+  console.log "[" + (Date.now() - start) + "] " + message
+
+log "Begin coffeescript-server.coffee"
+setTimeout (->
+  module.exports = app.listen(app.get("port"), ->
+    log "Express server listening on port " + app.get("port")
+  )
+), 50
+setTimeout (->
+  log "250ms timeout"
+), 250
+log "End coffeescript-server.coffee"

--- a/test/custom_cmd_test.js
+++ b/test/custom_cmd_test.js
@@ -1,0 +1,25 @@
+/*
+ * grunt-express-server
+ * https://github.com/ericclemmons/grunt-express-server
+ *
+ * Copyright (c) 2013 Eric Clemmons
+ * Licensed under the MIT license.
+ */
+
+'use strict';
+
+var get = require('./lib/get');
+
+module.exports.custom_output = {
+  test_runs_from_coffeescript_server: function(test) {
+    test.expect(2);
+
+    get('http://localhost:3000/', function(res, body) {
+      test.equal(res.statusCode, 200, 'should return 200');
+      test.equal(body, 'Howdy from CoffeeScript!', 'should return message from CoffeeScript server');
+      test.done();
+    }, function(err) {
+      test.done();
+    });
+  }
+};


### PR DESCRIPTION
This just adds a 'cmd' option to override the command used to start the server. Same as the first change from Pull Request https://github.com/ericclemmons/grunt-express-server/pull/7 with the additions of a test using a CoffeeScript server and documentation update.
