### PR TITLE
Fix multiple instances and no method 'async' bug

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -155,10 +155,18 @@ module.exports = function(grunt) {
     'express:custom_output',    'nodeunit:custom_output',   'express:custom_output:stop',
     'express:stoppable',        'express:stoppable:stop',   'nodeunit:stoppable',
 
+    // Multiple consecutive starts/stops of the same server
+    'express:custom_delay',     'nodeunit:custom_delay',    'express:custom_delay:stop',
+    'express:custom_delay',     'nodeunit:custom_delay',    'express:custom_delay:stop',
+    'express:custom_delay',     'nodeunit:custom_delay',    'express:custom_delay:stop',
+
     // Multiple servers
     'express:custom_port',      'express:defaults',
     'nodeunit:defaults',        'nodeunit:custom_port',
     'express:custom_port:stop', 'express:defaults:stop',
+
+    // Start but don't stop server
+    'express:defaults'
   ]);
 
   // By default, lint and run all tests.

--- a/tasks/lib/server.js
+++ b/tasks/lib/server.js
@@ -13,15 +13,16 @@ module.exports = function(grunt, target) {
     process._servers = {};
   }
 
-  var backup  = null;
-  var done    = null;
-  var server  = process._servers[target]; // Store server between live reloads to close/restart express
+  var backup    = null;
+  var startdone = null;
+  var stopdone  = null;
+  var server    = process._servers[target]; // Store server between live reloads to close/restart express
 
   var finished = function() {
-    if (done) {
-      done();
+    if (startdone) {
+      startdone();
 
-      done = null;
+      startdone = null;
     }
   };
 
@@ -50,7 +51,7 @@ module.exports = function(grunt, target) {
 
       grunt.log.writeln('Starting '.cyan + (options.background ? 'background' : 'foreground') + ' Express server');
 
-      done = grunt.task.current.async();
+      startdone = grunt.task.current.async();
 
       // Set PORT for new processes
       process.env.PORT = options.port;
@@ -71,7 +72,12 @@ module.exports = function(grunt, target) {
           args:     options.args,
           env:      process.env,
           fallback: options.fallback
-        }, finished);
+        }, function (error, result, code) {
+          if (stopdone) {
+            stopdone();
+          }
+          finished();
+        });
 
         if (options.delay) {
           setTimeout(finished, options.delay);
@@ -99,8 +105,14 @@ module.exports = function(grunt, target) {
     },
 
     stop: function() {
-      if (server && server.kill) {
+      if (server && server.kill) {        
         grunt.log.writeln('Stopping'.red + ' Express server');
+
+        // grunt.task.current.async() is no more available if stop is called
+        // from the 'exit' event.
+        if (typeof(grunt.task.current.async) === "function") {
+          stopdone = grunt.task.current.async();
+        }
 
         server.kill('SIGTERM');
         process.removeAllListeners();


### PR DESCRIPTION
closes #28
closes #30
- added stopdone to wait for server to stop
- renamed done to startdone
- added conditional for `grunt.task.current.async()`
- added testsequence which is able to reproduce the bug without my
  changes to server.js
- added `express:defaults` without `express:defaults:stop` at the end
  of the file to reproduce missing 'async'
