### PR TITLE
add --nodejs flag before --debug if using coffeescript (coffeefix)

### DIFF
--- a/tasks/lib/server.js
+++ b/tasks/lib/server.js
@@ -64,7 +64,7 @@ module.exports = function(grunt, target) {
       if(options.debug) {
         options.args.unshift('--debug');
         if(options.cmd === 'coffee') {
-          options.args.unshift('--nodejs')
+          options.args.unshift('--nodejs');
         }
       }
 


### PR DESCRIPTION
Here's a pull request fix for #37.
