### PR TITLE
Updated grunt-contrib-watch example for compatibility with older versions of grunt-contrib-watch in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ grunt.initConfig({
       files:  [ '**/*.js' ],
       tasks:  [ 'express:dev' ],
       options: {
-        spawn: false // Without this option specified express won't be reloaded
+        spawn: false // for grunt-contrib-watch v0.5.0+, "nospawn: true" for lower versions. Without this option specified express won't be reloaded
       }
     }
   }


### PR DESCRIPTION
Updated grunt-contrib-watch example.
Use "nospawn: true" instead of "spawn: false" for grunt-contrib-watch versions below v0.5.0.
