### PR TITLE
If the finish task is called with exit code 143 witch coresponds to SIGT...

### DIFF
--- a/tasks/lib/server.js
+++ b/tasks/lib/server.js
@@ -18,8 +18,9 @@ module.exports = function(grunt, target) {
   var server  = process._servers[target]; // Store server between live reloads to close/restart express
 
   var finished = function(error, result, code) {
-    if(code === 143)
+    if(code === 143) {
       return;
+    }
     if (done) {
       done();
 


### PR DESCRIPTION
I've tried to work with grunt-express-server here: https://github.com/nistormihai/grunt-express-server-test
on ubuntu precise 64
with livereload for node rendering but it seemed that the livereload was reloading the browser 
before the express server started.
I found out that somehow the finish process was triggered by  grunt.util.spawn with the exiting task,
and with the exit code 143 see here: http://stackoverflow.com/questions/4192364/always-app-java-end-with-exit-143-ubuntu

So my fix was just to exit if code 143 was received.
Maybe is not the best approach but I didn't had more time to investigate this thoroughly.
