### PR TITLE
Adds support for a new logs option

### DIFF
--- a/tasks/lib/server.js
+++ b/tasks/lib/server.js
@@ -90,8 +90,17 @@ module.exports = function(grunt, target) {
           });
         }
 
-        server.stdout.pipe(process.stdout);
-        server.stderr.pipe(process.stderr);
+        var out = process.stdout, err = process.stderr;
+	if(options.logs) {
+		var fs = require('fs'), path = require('path');
+		if(options.logs.out)
+			out = fs.createWriteStream(path.resolve(options.logs.out), {flags: 'a'});
+
+		if(options.logs.err)
+                        err = fs.createWriteStream(path.resolve(options.logs.err), {flags: 'a'});
+	}
+	server.stdout.pipe(out);
+	server.stderr.pipe(err);
       } else {
         // Server is ran in current process
         server = process._servers[target] = require(options.script);


### PR DESCRIPTION
This new option allows you to use files instead of stdout and stderr.
It is defined as follow :

``` js
logs: {
out: 'your stdout file',
err: 'your stderr file'
}
```

If you define one of this options, the server's stdout/stderr will be piped to the file with path.resolve and fs.createWriteStream with the flag 'a'.
If you don't define and option, the output will be redirected to process.stdout like it used to behave.
