### PR TITLE
coffee spawns own, uncontrollable child process

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,15 +64,13 @@ or within each individual server task.
     options: {
       // Override the command used to start the server.
       // (do not use 'coffee' here, the server will not be able to restart
-      //  see below at cmdArgs for coffee-script support)
+      //  see below at opts for coffee-script support)
       cmd: process.argv[0],
 
-      // Will turn into: `node CMDARG1 CMDARG2 ... CMDARGN path/to/server.js ARG1 ARG2 ... ARGN`
-      // (e.g. ['node_modules/coffee-script/bin/coffee'] will correctly parse coffee-script)
-      cmdArgs: [ ],
-
-      // Will turn into: `node path/to/server.js ARG1 ARG2 ... ARGN`
-      args: [ ],
+      // Will turn into: `node OPT1 OPT2 ... OPTN path/to/server.js ARG1 ARG2 ... ARGN`
+      // (e.g. opts: ['node_modules/coffee-script/bin/coffee'] will correctly parse coffee-script)
+      opts: [ ],
+      args: [ ],    
 
       // Setting to `false` will effectively just run `node path/to/server.js`
       background: true,

--- a/tasks/express.js
+++ b/tasks/express.js
@@ -23,7 +23,7 @@ module.exports = function(grunt) {
     var action  = this.args.shift() || 'start';
     var options = this.options({
       cmd:           process.argv[0],
-      cmdArgs:       [ ],
+      opts:          [ ],
       args:          [ ],
       node_env:      undefined,
       background:    true,

--- a/tasks/lib/server.js
+++ b/tasks/lib/server.js
@@ -63,22 +63,22 @@ module.exports = function(grunt, target) {
       if (options.cmd === 'coffee') {
         grunt.log.writeln('You are using cmd: coffee'.red);
         grunt.log.writeln('coffee does not allow a restart of the server'.red);
-        grunt.log.writeln('use cmdArgs: ["path/to/your/coffee"] instead'.red);
+        grunt.log.writeln('use opts: ["path/to/your/coffee"] instead'.red);
       }
       
 
       // Set debug mode for node-inspector
       if (options.debug) {
-        options.cmdArgs.unshift('--debug');
+        options.opts.unshift('--debug');
         if (options.cmd === 'coffee') {
-          options.cmdArgs.unshift('--nodejs');
+          options.opts.unshift('--nodejs');
         }
       }
 
       if (options.background) {
         server = process._servers[target] = grunt.util.spawn({
           cmd:      options.cmd,
-          args:     options.cmdArgs.concat(options.args),
+          args:     options.opts.concat(options.args),
           env:      process.env,
           fallback: options.fallback
         }, finished);


### PR DESCRIPTION
when using coffee as cmd the server is not restartable
workaround by using node with local coffe-script instead
(similar to [here](https://github.com/remy/nodemon/issues/195))

could be tested by comparing pid of child process on grunt/child side

without fix:
`
Starting background Express server
pid of serverchild on grunt side: 3048
pid of serverchild on child side: 8812
Express server listening on port 9000 in development mode
`
with fix:
`
Starting background Express server
You are using Coffee-script
coffee does not allow a restart of the server
found local coffee-script: ./node_modules/coffee-script/bin/coffee
using nodejs with local coffe-script instead
pid of serverchild on grunt side: 8416
pid of serverchild on child side: 8416
Express server listening on port 9000 in development mode
`
