### PR TITLE
Add ability to forward arbitrary --nodejs arguments to the node executab...

### DIFF
--- a/tasks/lib/server.js
+++ b/tasks/lib/server.js
@@ -27,6 +27,8 @@ module.exports = function(grunt, target) {
 
   return {
     start: function start(options) {
+      var i, len, nodejs_args;
+
       if (server) {
         this.stop();
 
@@ -65,6 +67,16 @@ module.exports = function(grunt, target) {
         options.args.unshift('--debug');
         if(options.cmd === 'coffee') {
           options.args.unshift('--nodejs');
+        }
+      }
+
+      nodejs_args = options.nodejs_args;
+
+      // Set any forwarded args to the node executable using the --nodejs option.
+      // E.g. --debug-brk, --expose-gc.
+      if (nodejs_args && nodejs_args.length) {
+        for (i = 0, len = nodejs_args.length; i < len; i++) {
+          options.args.unshift('--nodejs', nodejs_args[i]);
         }
       }
 


### PR DESCRIPTION
...le when using CoffeeScript, IcedCoffeeScrit, etc.

For interpreters that call the node executable indirectly (e.g. CoffeeScript, IcedCoffeeScript), it would be nice to have the ability to forward arbitrary arguments like --debug-brk, --max-stack-size to node.

I saw that debug for CoffeeScript was added for issue #37 but I couldn't use it since I am using IcedCoffeeScript and the name of the command I'm using in options.cmd isn't 'coffee'.

Basically, this solves the problem in a more generic way than #37, allowing you to pass arguments other than --debug and not only for 'coffee' executables.
