### PR TITLE
Allow debug: option to be specified as (integer) port number.

### DIFF
--- a/tasks/lib/server.js
+++ b/tasks/lib/server.js
@@ -68,7 +68,11 @@ module.exports = function(grunt, target) {
 
       // Set debug mode for node-inspector
       if (options.debug) {
-        options.opts.unshift('--debug');
+        if(!isNaN(parseInt(options.debug, 10))) {
+          options.opts.unshift('--debug=' + options.debug);
+        } else {
+          options.opts.unshift('--debug');
+        }
         if (options.cmd === 'coffee') {
           options.opts.unshift('--nodejs');
         }


### PR DESCRIPTION
I needed to be able to specify a custom debugging port while using grunt-express-server. This patch enables this functionality.

In addition to `debug: true` and `debug: false`, this patch will take an integer as a port number to start the node debugger on. All of these are valid examples:

``` javascript
    express: {
      options: {
        port: process.env.PORT || 9000
      },
      dev: {
        options: {
          script: 'server/app.js',
          debug: 5959
        }
      },
```

``` javascript
    express: {
      options: {
        port: process.env.PORT || 9000
      },
      dev: {
        options: {
          script: 'server/app.js',
          debug: false
        }
      },
```

``` javascript
    express: {
      options: {
        port: process.env.PORT || 9000
      },
      dev: {
        options: {
          script: 'server/app.js',
          debug: true
        }
      },
```
