### PR TITLE
Changed the treatment of the debug option so that a port can be set in c...

### DIFF
--- a/tasks/lib/server.js
+++ b/tasks/lib/server.js
@@ -69,7 +69,8 @@ module.exports = function(grunt, target) {
       // Set debug mode for node-inspector
       // Based on https://github.com/joyent/node/blob/master/src/node.cc#L2903
       if (options.debug === true) {
-        options.opts.unshift('--debug');
+        var arg = options.debug === true ? '--debug' : '--debug=' + options.debug;
+        options.opts.unshift(arg);
       } else if (!isNaN(parseInt(options.debug, 10))) {
         options.opts.unshift('--debug=' + options.debug);
       } else if (options.breakOnFirstLine === true) {


### PR DESCRIPTION
...onfiguration from the grunt file

Hi eric,

while running multiple node apps and wanting to debug them, I found that I couldn't set a debug port through the configuration in the grunt file. After investigating I found that the grunt task doesn't pick up the port - just whether debug is set or not.

I couldn't see any tests for the debug settings - so wasn't sure where to put the test for this, or indeed how to test this. If you'd like a test, please suggest where to put it and perhaps how best to test it.

Ed