### PR TITLE
Option to use SIGKILL when stopping server

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ or within each individual server task.
       // Set --debug-brk (true | false | integer from 1024 to 65535)
       breakOnFirstLine: false,
 
-      // Object with properties `out` and `err` both will take a path to a log file and  
+      // Object with properties `out` and `err` both will take a path to a log file and
       // append the output of the server. Make sure the folders exist.
       logs: undefined
 
@@ -199,6 +199,7 @@ In lieu of a formal styleguide, take care to maintain the existing coding style.
 
 ## Release History
 
+- v0.5.2 - Add `hardStop` flag ([#99](https://github.com/ericclemmons/grunt-express-server/pull/99))
 - v0.5.1 - Add `harmony` flag ([#86](https://github.com/ericclemmons/grunt-express-server/pull/86))
 - v0.5.0 - Add breakOnFirstLine option, support for debug ports and fix bugs. Details: ([#68](https://github.com/ericclemmons/grunt-express-server/pull/68), [#70](https://github.com/ericclemmons/grunt-express-server/pull/70), [#73](https://github.com/ericclemmons/grunt-express-server/pull/73))
 - v0.4.19 – Use `process.env.PORT` before `3000` ([#59](https://github.com/ericclemmons/grunt-express-server/pull/59))
@@ -232,4 +233,3 @@ In lieu of a formal styleguide, take care to maintain the existing coding style.
 
 
 [![Bitdeli Badge](https://d2weczhvl823v0.cloudfront.net/ericclemmons/grunt-express-server/trend.png)](https://bitdeli.com/free "Bitdeli Badge")
-

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-express-server",
   "description": "Grunt task for running an Express Server that works great with LiveReload + Watch/Regarde",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "homepage": "https://github.com/ericclemmons/grunt-express-server",
   "author": {
     "name": "Eric Clemmons",

--- a/tasks/express.js
+++ b/tasks/express.js
@@ -34,7 +34,8 @@ module.exports = function(grunt) {
       output:           ".+",
       debug:            false,
       breakOnFirstLine: false,
-      logs:             undefined
+      logs:             undefined,
+      hardStop:         false
     });
 
     options.script = path.resolve(options.script);

--- a/tasks/lib/server.js
+++ b/tasks/lib/server.js
@@ -132,7 +132,7 @@ module.exports = function(grunt, target) {
       if (server && server.kill) {
         grunt.log.writeln('Stopping'.red + ' Express server');
         server.removeAllListeners('close');
-        server.kill('SIGTERM');
+        server.kill('SIGKILL');
         process.removeListener('exit', finished);
         process.removeListener('exit', stop);
         server = process._servers[target] = null;

--- a/tasks/lib/server.js
+++ b/tasks/lib/server.js
@@ -28,7 +28,7 @@ module.exports = function(grunt, target) {
   return {
     start: function start(options) {
       if (server) {
-        this.stop();
+        this.stop(options);
 
         if (grunt.task.current.flags.stop) {
           finished();
@@ -128,11 +128,16 @@ module.exports = function(grunt, target) {
       process.on('exit', this.stop);
     },
 
-    stop: function stop() {
+    stop: function stop(options) {
       if (server && server.kill) {
         grunt.log.writeln('Stopping'.red + ' Express server');
         server.removeAllListeners('close');
-        server.kill('SIGKILL');
+        if (options.hardStop) {
+          grunt.log.writeln('Using ' + 'SIGKILL'.red);
+          server.kill('SIGKILL');
+        } else {
+          server.kill('SIGTERM');
+        }
         process.removeListener('exit', finished);
         process.removeListener('exit', stop);
         server = process._servers[target] = null;


### PR DESCRIPTION
This PR remedies an issue where the node process spawned by grunt ignores `SIGTERM`, failing to shut down and generating the error `EADDRINUSE` (see, _e.g._, #14). 

The PR integrates an option called `hardStop`, passable via the usual options json, to send the `SIGKILL` command instead of `SIGTERM` when stopping the spawned process.