### PR TITLE
On stop, options param now optional

### DIFF
--- a/tasks/lib/server.js
+++ b/tasks/lib/server.js
@@ -132,7 +132,7 @@ module.exports = function(grunt, target) {
       if (server && server.kill) {
         grunt.log.writeln('Stopping'.red + ' Express server');
         server.removeAllListeners('close');
-        if (options.hardStop) {
+        if (options && options.hardStop) {
           grunt.log.writeln('Using ' + 'SIGKILL'.red);
           server.kill('SIGKILL');
         } else {


### PR DESCRIPTION
I couldn't quite isolate the cause, but sometimes my server would crash with the error

Fatal error: Cannot read property 'hardStop' of null

I'm guessing that sometimes options aren't passed through to the stop command, so I made the options parameter optional for the if statement. Grunt server doesn't crash now, which I guess is a good sign.
